### PR TITLE
Make interface rates consistent with labels (MBps -> Mbps)

### DIFF
--- a/dashboards/templates/graphs/dev-int-bytes-sum.yaml
+++ b/dashboards/templates/graphs/dev-int-bytes-sum.yaml
@@ -1,16 +1,16 @@
 
 
-title: "Traffic Statistics (BPS)"
+title: "Traffic Statistics (bps)"
 template: prom-graph-lines-01.j2
 datasource: prometheus
 span: 4
 
 targets:
   A:
-    expr: avg(interface_counters_tx_bytes{device=~"$device"}/5) by (device, interface)
+    expr: avg(8*interface_counters_tx_bytes{device=~"$device"}/5) by (device, interface)
     legend: "{{ interface }} - TX"
   B:
-    expr: avg(interface_counters_rx_bytes{device=~"$device"}/5) by (device, interface)
+    expr: avg(8*interface_counters_rx_bytes{device=~"$device"}/5) by (device, interface)
     legend: "{{ interface }} - RX"
 
 yaxes:


### PR DESCRIPTION
In Apstra AOS Device dashboard, the interface counters rates use *bps (bits per second) units, but metrics refer to bytes.