### PR TITLE
Fixed the Readme.rst to show only the 8086 port being used by influxdb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Here is an example of BGP Neighbors being offline.
 InfluxDB
 ========
 InfluxDB is used to store AOS events from telemetry streaming.  InfluxDB is
-available by viewing http://<aosom-streaming>:8083
+available by viewing http://<aosom-streaming>:8086
 
 We can show the available influxdb keys with queries, such as ‘show field keys’
 or ‘show measurements’.
@@ -399,7 +399,6 @@ Modifying docker options::
      # influxdb
     @@ -43,6 +45,7 @@ services:
          ports:
-          - "8083:8083"
           - "8086:8086"
     +    restart: always
 
@@ -471,6 +470,6 @@ Listing docker containers::
     3042d45f1107        prom/prometheus:v1.5.2   "/bin/prometheus -con"   3 minutes ago       Up 3 minutes        0.0.0.0:9090->9090/tcp                           aosomstreaming_prometheus_1
     429328fbb5ac        apstra/telegraf:1.2      "telegraf -debug"        3 minutes ago       Up 3 minutes        0.0.0.0:6666->6666/tcp                           aosomstreaming_telegraf-prom_1
     0a84241e1366        apstra/telegraf:1.2      "telegraf -debug"        3 minutes ago       Up 3 minutes        0.0.0.0:4444->4444/tcp                           aosomstreaming_telegraf-influx_1
-    f4d2deb0e428        influxdb:1.1.1-alpine    "/entrypoint.sh influ"   3 minutes ago       Up 3 minutes        0.0.0.0:8083->8083/tcp, 0.0.0.0:8086->8086/tcp   aosomstreaming_influxdb_1
+    f4d2deb0e428        influxdb:1.1.1-alpine    "/entrypoint.sh influ"   3 minutes ago       Up 3 minutes        0.0.0.0:8086->8086/tcp   aosomstreaming_influxdb_1
 
 


### PR DESCRIPTION
The docker.yml makes no reference to port 8083, and as it exists right now, the documentation is a bit misleading.
Here's a copy of the docker ps command from a currenrly running instance.

[root@HelperVM-01160 ~]# docker ps
CONTAINER ID   IMAGE                    COMMAND                  CREATED      STATUS      PORTS                                                                     NAMES
adef0f482eb9   grafana/grafana:5.4.3    "/run.sh"                4 days ago   Up 4 days   0.0.0.0:3000->3000/tcp, :::3000->3000/tcp                                 aosomstreaming_grafana_1
9cafa8419695   influxdb:1.8.2-alpine    "/entrypoint.sh infl…"   4 days ago   Up 4 days   0.0.0.0:8086->8086/tcp, :::8086->8086/tcp                                 aosomstreaming_influxdb_1
d276804a82b5   apstra/telegraf:latest   "/entrypoint.sh tele…"   4 days ago   Up 4 days   8092/udp, 0.0.0.0:6666->6666/tcp, :::6666->6666/tcp, 8125/udp, 8094/tcp   aosomstreaming_telegraf-prom_1
997e5e2cb1d3   prom/prometheus:v2.4.3   "/bin/prometheus --c…"   4 days ago   Up 4 days   0.0.0.0:9090->9090/tcp, :::9090->9090/tcp                                 aosomstreaming_prometheus_1
1e474c85b321   apstra/telegraf:latest   "/entrypoint.sh tele…"   4 days ago   Up 4 days   8092/udp, 0.0.0.0:4444->4444/tcp, :::4444->4444/tcp, 8125/udp, 8094/tcp   aosomstreaming_telegraf-influx_1