### PR TITLE
Pin telegraf image version

### DIFF
--- a/docker-compose-es.yml
+++ b/docker-compose-es.yml
@@ -31,7 +31,7 @@ services:
 # Telegraf - Elasticsearch
 # -------------------------------------------------------------------------
   telegraf-elasticsearch:
-    image: apstra/telegraf:latest
+    image: apstra/telegraf:1.12_AOS_3.2
     command: telegraf -debug
     env_file:
       - variables.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 # Telegraf - Prom
 # -------------------------------------------------------------------------
   telegraf-prom:
-    image: apstra/telegraf:latest
+    image: apstra/telegraf:1.12_AOS_3.2
     command: telegraf -debug
     env_file:
       - variables.env
@@ -63,7 +63,7 @@ services:
 # Telegraf - Influx
 # -------------------------------------------------------------------------
   telegraf-influx:
-    image: apstra/telegraf:latest
+    image: apstra/telegraf:1.12_AOS_3.2
     command: telegraf -debug
     env_file:
       - variables.env

--- a/ecr.docker-compose.yml
+++ b/ecr.docker-compose.yml
@@ -49,7 +49,7 @@ services:
 # Telegraf - Prom
 # -------------------------------------------------------------------------
   telegraf-prom:
-    image: public.ecr.aws/q1z9q2b2/apstra/telegraf:latest
+    image: public.ecr.aws/q1z9q2b2/apstra/telegraf:1.12_AOS_3.2
     command: telegraf -debug
     env_file:
       - variables.env
@@ -63,7 +63,7 @@ services:
 # Telegraf - Influx
 # -------------------------------------------------------------------------
   telegraf-influx:
-    image: public.ecr.aws/q1z9q2b2/apstra/telegraf:latest
+    image: public.ecr.aws/q1z9q2b2/apstra/telegraf:1.12_AOS_3.2
     command: telegraf -debug
     env_file:
       - variables.env


### PR DESCRIPTION
We would like to update `apstra/telegraf` image in future, so, pin current latest version to named tag.
The `latest` and `1.12_AOS_3.2` have the same digest now: https://hub.docker.com/r/apstra/telegraf/tags