### PR TITLE
fix config path to match the one expected by grafana server

### DIFF
--- a/ecr.docker-compose.yml
+++ b/ecr.docker-compose.yml
@@ -7,11 +7,11 @@ services:
 # Grafana - Graphical Interface
 # -------------------------------------------------------------------------
   grafana:
-    image: public.ecr.aws/q1z9q2b2/grafana/grafana:5.4.3
+    image: public.ecr.aws/ubuntu/grafana:11.0.0-22.04_stable
     volumes:
       - /etc/localtime:/etc/localtime
       - grafana_data_2:/var/lib/grafana
-      - ./config/grafana.ini:/etc/grafana/grafana.ini
+      - ./config/grafana.ini:/etc/grafana/grafana-config.ini
     depends_on:
       - prometheus
     ports:

--- a/grafana_healthcheck.sh
+++ b/grafana_healthcheck.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+GRAFANA_LOGIN=${GRAFANA_LOGIN:-admin}
+GRAFANA_PASSWORD=${GRAFANA_PASSWORD:-aos-aos}
+
 source ./variables.env
 
 function check_grafana () {


### PR DESCRIPTION
Grafana server now reads from file /etc/grafana/grafana-config.ini - adjust this path in docker-compose. Also add default login admin/aos-aos to healthcheck script for curl call.