### PR TITLE
CL-2562 Some systems don't have `docker-compose` binary, make `Makefi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,22 +25,22 @@ help:
 ## Start all components
 start:
 	@echo "-- Start all components --"
-	docker-compose up -d
+	@./docker_compose.sh up -d
 
 ## Stop all components
 stop:
 	@echo "-- Stop all components --"
-	@docker-compose down
+	@./docker_compose.sh down
 
 ## Start all components using ECR images to prevent docker pull quota limits
 start-ecr:
 	@echo "-- Start all components --"
-	docker-compose -f ecr.docker-compose.yml up -d
+	@./docker_compose.sh -f ecr.docker-compose.yml up -d
 	timeout 1m ./grafana_healthcheck.sh || echo Grafana startup timed out
 
 stop-ecr:
 	@echo "-- Start all components --"
-	docker-compose -f ecr.docker-compose.yml down
+	@./docker_compose.sh -f ecr.docker-compose.yml down
 
 ## Create datasources (proxy) in grafana and load Dashboards (grafana-create-source-proxy grafana-load-dashboards)
 init: grafana-create-source-proxy grafana-load-dashboards
@@ -75,7 +75,7 @@ update: stop update-docker start grafana-load-dashboards
 ## Update Docker Images
 update-docker:
 	@echo "-- Download Latest Images from Docker Hub --"
-	@docker-compose pull --ignore-pull-failures
+	@./docker_compose.sh pull --ignore-pull-failures
 
 ## Delete Grafana information and delete current streaming session on AOS (clean-docker clean-aos)
 clean: clean-docker # clean-aos

--- a/docker_compose.sh
+++ b/docker_compose.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Some systems may not have docker-compose installed as docker-compose, but as docker compose
+
+set -e
+
+if command -v docker-compose &> /dev/null; then
+  docker-compose $@
+else
+  docker compose $@
+fi


### PR DESCRIPTION
…le` compatible

Systems may fail with

```
 ~ command: cd aosom-streaming ; sudo /usr/bin/make start
 ~ Using sudo: False
 ~ stdout: -- Start all components --
 ~ stderr: make: docker-compose: No such file or directory
 ~ stderr: make: *** [Makefile:28: start] Error 127
 ~ exit status: 2
 ```

 Resolve by checking if target system has `docker-compose` binary and use it conditionally